### PR TITLE
White space issue fixed

### DIFF
--- a/src/utils/split-text.js
+++ b/src/utils/split-text.js
@@ -46,7 +46,7 @@ export function splitText(el, key, splitOn, includePrevious, preserveWhitespace)
         if (contents.length) {
             // insert leading space if there was one
             if (wholeText[0] === ' ') {
-                allElements.push(createText(' '));
+                allElements.push(createElement(F, "whitespace", " ", preserveWhitespace));
             }
             // Concatenate the split text children back into the full array
             each(contents.split(splitOn), function(splitText, i) {
@@ -59,7 +59,7 @@ export function splitText(el, key, splitOn, includePrevious, preserveWhitespace)
             }); 
             // insert trailing space if there was one
             if (wholeText[wholeText.length - 1] === ' ') {
-                allElements.push(createText(' '));
+                allElements.push(createElement(F, "whitespace", " ", preserveWhitespace));
             }
         }
     });


### PR DESCRIPTION
Before this edit, on lines 49 and 62, you were using `createText` to insert a whitespace before and after certain elements. This would add the whitespace so the sentence didn't have any missing whitespaces, but those new whitespaces weren't being added to the allElements array. This makes those newly create whitespaces to be un-splittable. By taking line 54 and replacing lines 46. and 62. you add these whitespaces to the allElements array, allowing them to be split correctly.