### PR TITLE
Adds support for emojis by using the Intl.Segmenter when splitting characters

### DIFF
--- a/dist/splitting-lite.js
+++ b/dist/splitting-lite.js
@@ -244,7 +244,8 @@ function splitText(el, key, splitOn, includePrevious, preserveWhitespace) {
                 allElements.push(createText(' '));
             }
             // Concatenate the split text children back into the full array
-            each(contents.split(splitOn), function(splitText, i) {
+            var useSegmenter = splitOn === "" && typeof Intl.Segmenter === "function";
+            each(useSegmenter ? Array.from(new Intl.Segmenter().segment(contents)).map(function(x){return x.segment}) : contents.split(splitOn), function (splitText, i) {
                 if (i && preserveWhitespace) {
                     allElements.push(createElement(F, "whitespace", " ", preserveWhitespace));
                 }

--- a/dist/splitting-lite.min.js
+++ b/dist/splitting-lite.min.js
@@ -1,31 +1,31 @@
 !function(t,n){"object"==typeof exports&&"undefined"!=typeof module?module.exports=n():"function"==typeof define&&define.amd?define(n):t.Splitting=n()}(this,function(){"use strict"
-var u=document,d=u.createTextNode.bind(u)
-function l(t,n,e){t.style.setProperty(n,e)}function f(t,n){return t.appendChild(n)}function p(t,n,e,r){var i=u.createElement("span")
-return n&&(i.className=n),e&&(!r&&i.setAttribute("data-"+n,e),i.textContent=e),t&&f(t,i)||i}function n(t,n){return t&&0!=t.length?t.nodeName?[t]:[].slice.call(t[0].nodeName?t:(n||u).querySelectorAll(t)):[]}function h(t,n){t&&t.some(n)}var a={}
+var u=document,f=u.createTextNode.bind(u)
+function d(t,n,e){t.style.setProperty(n,e)}function l(t,n){return t.appendChild(n)}function p(t,n,e,r){var i=u.createElement("span")
+return n&&(i.className=n),e&&(!r&&i.setAttribute("data-"+n,e),i.textContent=e),t&&l(t,i)||i}function n(t,n){return t&&0!=t.length?t.nodeName?[t]:[].slice.call(t[0].nodeName?t:(n||u).querySelectorAll(t)):[]}function h(t,n){t&&t.some(n)}var a={}
 function t(t,n,e,r){return{by:t,depends:n,key:e,split:r}}function i(t){return function n(e,t,r){var i=r.indexOf(e)
 if(-1==i){r.unshift(e)
 var u=a[e]
 if(!u)throw new Error("plugin not loaded: "+e)
 h(u.depends,function(t){n(t,e,r)})}else{var o=r.indexOf(t)
 r.splice(i,1),r.splice(o,0,e)}return r}(t,0,[]).map((n=a,function(t){return n[t]}))
-var n}function e(t){a[t.by]=t}function v(t,r,i,u,o){t.normalize()
+var n}function e(t){a[t.by]=t}function m(t,r,i,u,o){t.normalize()
 var a=[],s=document.createDocumentFragment()
 u&&a.push(t.previousSibling)
 var c=[]
-return n(t.childNodes).some(function(t){if(!t.tagName||t.hasChildNodes()){if(t.childNodes&&t.childNodes.length)return c.push(t),void a.push.apply(a,v(t,r,i,u,o))
+return n(t.childNodes).some(function(t){if(!t.tagName||t.hasChildNodes()){if(t.childNodes&&t.childNodes.length)return c.push(t),void a.push.apply(a,m(t,r,i,u,o))
 var n=t.wholeText||"",e=n.trim()
-e.length&&(" "===n[0]&&c.push(d(" ")),h(e.split(i),function(t,n){n&&o&&c.push(p(s,"whitespace"," ",o))
+if(e.length)" "===n[0]&&c.push(f(" ")),h(""===i&&"function"==typeof Intl.Segmenter?Array.from((new Intl.Segmenter).segment(e)).map(function(t){return t.segment}):e.split(i),function(t,n){n&&o&&c.push(p(s,"whitespace"," ",o))
 var e=p(s,r,t)
-a.push(e),c.push(e)})," "===n[n.length-1]&&c.push(d(" ")))}else c.push(t)}),h(c,function(t){f(s,t)}),t.innerHTML="",f(t,s),a}var o="words",r=t(o,0,"word",function(t){return v(t,"word",/\s+/,0,1)}),m="chars",s=t(m,[o],"char",function(t,e,n){var r=[]
-return h(n[o],function(t,n){r.push.apply(r,v(t,"char","",e.whitespace&&n))}),r})
-function c(r){var f=(r=r||{}).key
+a.push(e),c.push(e)})," "===n[n.length-1]&&c.push(f(" "))}else c.push(t)}),h(c,function(t){l(s,t)}),t.innerHTML="",l(t,s),a}var o="words",r=t(o,0,"word",function(t){return m(t,"word",/\s+/,0,1)}),v="chars",s=t(v,[o],"char",function(t,e,n){var r=[]
+return h(n[o],function(t,n){r.push.apply(r,m(t,"char","",e.whitespace&&n))}),r})
+function c(r){var l=(r=r||{}).key
 return n(r.target||"[data-splitting]").map(function(s){var c=s["🍌"]
 if(!r.force&&c)return c
 c=s["🍌"]={el:s}
 var t,n=r.by||(t="splitting",s.getAttribute("data-"+t))
-n&&"true"!=n||(n=m)
-var e=i(n),d=function(t,n){for(var e in n)t[e]=n[e]
+n&&"true"!=n||(n=v)
+var e=i(n),f=function(t,n){for(var e in n)t[e]=n[e]
 return t}({},r)
-return h(e,function(t){if(t.split){var n=t.by,e=(f?"-"+f:"")+t.key,r=t.split(s,d,c)
-e&&(i=s,a=(o="--"+e)+"-index",h(u=r,function(t,n){Array.isArray(t)?h(t,function(t){l(t,a,n)}):l(t,a,n)}),l(i,o+"-total",u.length)),c[n]=r,s.classList.add(n)}var i,u,o,a}),s.classList.add("splitting"),c})}return c.html=function(t){var n=(t=t||{}).target=p()
+return h(e,function(t){if(t.split){var n=t.by,e=(l?"-"+l:"")+t.key,r=t.split(s,f,c)
+e&&(i=s,a=(o="--"+e)+"-index",h(u=r,function(t,n){Array.isArray(t)?h(t,function(t){d(t,a,n)}):d(t,a,n)}),d(i,o+"-total",u.length)),c[n]=r,s.classList.add(n)}var i,u,o,a}),s.classList.add("splitting"),c})}return c.html=function(t){var n=(t=t||{}).target=p()
 return n.innerHTML=t.content,c(t),n.outerHTML},(c.add=e)(r),e(s),c})

--- a/dist/splitting.js
+++ b/dist/splitting.js
@@ -250,7 +250,8 @@ function splitText(el, key, splitOn, includePrevious, preserveWhitespace) {
                 allElements.push(createText(' '));
             }
             // Concatenate the split text children back into the full array
-            each(contents.split(splitOn), function(splitText, i) {
+            var useSegmenter = splitOn === "" && typeof Intl.Segmenter === "function";
+            each(useSegmenter ? Array.from(new Intl.Segmenter().segment(contents)).map(function(x){return x.segment}) : contents.split(splitOn), function (splitText, i) {
                 if (i && preserveWhitespace) {
                     allElements.push(createElement(F, "whitespace", " ", preserveWhitespace));
                 }

--- a/dist/splitting.min.js
+++ b/dist/splitting.min.js
@@ -1,41 +1,41 @@
 !function(n,t){"object"==typeof exports&&"undefined"!=typeof module?module.exports=t():"function"==typeof define&&define.amd?define(t):n.Splitting=t()}(this,function(){"use strict"
 var o=document,l=o.createTextNode.bind(o)
 function d(n,t,e){n.style.setProperty(t,e)}function f(n,t){return n.appendChild(t)}function p(n,t,e,r){var i=o.createElement("span")
-return t&&(i.className=t),e&&(!r&&i.setAttribute("data-"+t,e),i.textContent=e),n&&f(n,i)||i}function h(n,t){return n.getAttribute("data-"+t)}function m(n,t){return n&&0!=n.length?n.nodeName?[n]:[].slice.call(n[0].nodeName?n:(t||o).querySelectorAll(n)):[]}function u(n){for(var t=[];n--;)t[n]=[]
-return t}function v(n,t){n&&n.some(t)}function c(t){return function(n){return t[n]}}var a={}
+return t&&(i.className=t),e&&(!r&&i.setAttribute("data-"+t,e),i.textContent=e),n&&f(n,i)||i}function m(n,t){return n.getAttribute("data-"+t)}function h(n,t){return n&&0!=n.length?n.nodeName?[n]:[].slice.call(n[0].nodeName?n:(t||o).querySelectorAll(n)):[]}function u(n){for(var t=[];n--;)t[n]=[]
+return t}function g(n,t){n&&n.some(t)}function c(t){return function(n){return t[n]}}var a={}
 function n(n,t,e,r){return{by:n,depends:t,key:e,split:r}}function r(n){return function t(e,n,r){var i=r.indexOf(e)
 if(-1==i){r.unshift(e)
 var o=a[e]
 if(!o)throw new Error("plugin not loaded: "+e)
-v(o.depends,function(n){t(n,e,r)})}else{var u=r.indexOf(n)
-r.splice(i,1),r.splice(u,0,e)}return r}(n,0,[]).map(c(a))}function t(n){a[n.by]=n}function g(n,r,i,o,u){n.normalize()
+g(o.depends,function(n){t(n,e,r)})}else{var u=r.indexOf(n)
+r.splice(i,1),r.splice(u,0,e)}return r}(n,0,[]).map(c(a))}function t(n){a[n.by]=n}function v(n,r,i,o,u){n.normalize()
 var c=[],a=document.createDocumentFragment()
 o&&c.push(n.previousSibling)
 var s=[]
-return m(n.childNodes).some(function(n){if(!n.tagName||n.hasChildNodes()){if(n.childNodes&&n.childNodes.length)return s.push(n),void c.push.apply(c,g(n,r,i,o,u))
+return h(n.childNodes).some(function(n){if(!n.tagName||n.hasChildNodes()){if(n.childNodes&&n.childNodes.length)return s.push(n),void c.push.apply(c,v(n,r,i,o,u))
 var t=n.wholeText||"",e=t.trim()
-e.length&&(" "===t[0]&&s.push(l(" ")),v(e.split(i),function(n,t){t&&u&&s.push(p(a,"whitespace"," ",u))
+if(e.length)" "===t[0]&&s.push(l(" ")),g(""===i&&"function"==typeof Intl.Segmenter?Array.from((new Intl.Segmenter).segment(e)).map(function(n){return n.segment}):e.split(i),function(n,t){t&&u&&s.push(p(a,"whitespace"," ",u))
 var e=p(a,r,n)
-c.push(e),s.push(e)})," "===t[t.length-1]&&s.push(l(" ")))}else s.push(n)}),v(s,function(n){f(a,n)}),n.innerHTML="",f(n,a),c}var s=0
-var i="words",e=n(i,s,"word",function(n){return g(n,"word",/\s+/,0,1)}),y="chars",w=n(y,[i],"char",function(n,e,t){var r=[]
-return v(t[i],function(n,t){r.push.apply(r,g(n,"char","",e.whitespace&&t))}),r})
+c.push(e),s.push(e)})," "===t[t.length-1]&&s.push(l(" "))}else s.push(n)}),g(s,function(n){f(a,n)}),n.innerHTML="",f(n,a),c}var s=0
+var i="words",e=n(i,s,"word",function(n){return v(n,"word",/\s+/,0,1)}),y="chars",w=n(y,[i],"char",function(n,e,t){var r=[]
+return g(t[i],function(n,t){r.push.apply(r,v(n,"char","",e.whitespace&&t))}),r})
 function b(e){var f=(e=e||{}).key
-return m(e.target||"[data-splitting]").map(function(a){var s=a["🍌"]
+return h(e.target||"[data-splitting]").map(function(a){var s=a["🍌"]
 if(!e.force&&s)return s
 s=a["🍌"]={el:a}
-var n=e.by||h(a,"splitting")
+var n=e.by||m(a,"splitting")
 n&&"true"!=n||(n=y)
 var t=r(n),l=function(n,t){for(var e in t)n[e]=t[e]
 return n}({},e)
-return v(t,function(n){if(n.split){var t=n.by,e=(f?"-"+f:"")+n.key,r=n.split(a,l,s)
-e&&(i=a,c=(u="--"+e)+"-index",v(o=r,function(n,t){Array.isArray(n)?v(n,function(n){d(n,c,t)}):d(n,c,t)}),d(i,u+"-total",o.length)),s[t]=r,a.classList.add(t)}var i,o,u,c}),a.classList.add("splitting"),s})}function N(n,t,e){var r=m(t.matching||n.children,n),i={}
-return v(r,function(n){var t=Math.round(n[e]);(i[t]||(i[t]=[])).push(n)}),Object.keys(i).map(Number).sort(x).map(c(i))}function x(n,t){return n-t}b.html=function(n){var t=(n=n||{}).target=p()
+return g(t,function(n){if(n.split){var t=n.by,e=(f?"-"+f:"")+n.key,r=n.split(a,l,s)
+e&&(i=a,c=(u="--"+e)+"-index",g(o=r,function(n,t){Array.isArray(n)?g(n,function(n){d(n,c,t)}):d(n,c,t)}),d(i,u+"-total",o.length)),s[t]=r,a.classList.add(t)}var i,o,u,c}),a.classList.add("splitting"),s})}function N(n,t,e){var r=h(t.matching||n.children,n),i={}
+return g(r,function(n){var t=Math.round(n[e]);(i[t]||(i[t]=[])).push(n)}),Object.keys(i).map(Number).sort(x).map(c(i))}function x(n,t){return n-t}b.html=function(n){var t=(n=n||{}).target=p()
 return t.innerHTML=n.content,b(n),t.outerHTML},b.add=t
-var T=n("lines",[i],"line",function(n,t,e){return N(n,{matching:e[i]},"offsetTop")}),L=n("items",s,"item",function(n,t){return m(t.matching||n.children,n)}),k=n("rows",s,"row",function(n,t){return N(n,t,"offsetTop")}),A=n("cols",s,"col",function(n,t){return N(n,t,"offsetLeft")}),C=n("grid",["rows","cols"]),M="layout",S=n(M,s,s,function(n,t){var e=t.rows=+(t.rows||h(n,"rows")||1),r=t.columns=+(t.columns||h(n,"columns")||1)
-if(t.image=t.image||h(n,"image")||n.currentSrc||n.src,t.image){var i=m("img",n)[0]
+var S=n("lines",[i],"line",function(n,t,e){return N(n,{matching:e[i]},"offsetTop")}),T=n("items",s,"item",function(n,t){return h(t.matching||n.children,n)}),A=n("rows",s,"row",function(n,t){return N(n,t,"offsetTop")}),L=n("cols",s,"col",function(n,t){return N(n,t,"offsetLeft")}),k=n("grid",["rows","cols"]),C="layout",M=n(C,s,s,function(n,t){var e=t.rows=+(t.rows||m(n,"rows")||1),r=t.columns=+(t.columns||m(n,"columns")||1)
+if(t.image=t.image||m(n,"image")||n.currentSrc||n.src,t.image){var i=h("img",n)[0]
 t.image=i&&(i.currentSrc||i.src)}t.image&&d(n,"background-image","url("+t.image+")")
 for(var o=e*r,u=[],c=p(s,"cell-grid");o--;){var a=p(c,"cell")
-p(a,"cell-inner"),u.push(a)}return f(n,c),u}),H=n("cellRows",[M],"row",function(n,t,e){var r=t.rows,i=u(r)
-return v(e[M],function(n,t,e){i[Math.floor(t/(e.length/r))].push(n)}),i}),O=n("cellColumns",[M],"col",function(n,t,e){var r=t.columns,i=u(r)
-return v(e[M],function(n,t){i[t%r].push(n)}),i}),j=n("cells",["cellRows","cellColumns"],"cell",function(n,t,e){return e[M]})
-return t(e),t(w),t(T),t(L),t(k),t(A),t(C),t(S),t(H),t(O),t(j),b})
+p(a,"cell-inner"),u.push(a)}return f(n,c),u}),H=n("cellRows",[C],"row",function(n,t,e){var r=t.rows,i=u(r)
+return g(e[C],function(n,t,e){i[Math.floor(t/(e.length/r))].push(n)}),i}),O=n("cellColumns",[C],"col",function(n,t,e){var r=t.columns,i=u(r)
+return g(e[C],function(n,t){i[t%r].push(n)}),i}),j=n("cells",["cellRows","cellColumns"],"cell",function(n,t,e){return e[C]})
+return t(e),t(w),t(S),t(T),t(A),t(L),t(k),t(M),t(H),t(O),t(j),b})

--- a/src/utils/split-text.js
+++ b/src/utils/split-text.js
@@ -49,7 +49,8 @@ export function splitText(el, key, splitOn, includePrevious, preserveWhitespace)
                 allElements.push(createText(' '));
             }
             // Concatenate the split text children back into the full array
-            each(contents.split(splitOn), function(splitText, i) {
+            const useSegmenter = splitOn === "" && typeof Intl.Segmenter === "function";
+            each(useSegmenter ? [...new Intl.Segmenter().segment(contents)].map((x) => x.segment) : contents.split(splitOn), function (splitText, i) {
                 if (i && preserveWhitespace) {
                     allElements.push(createElement(F, "whitespace", " ", preserveWhitespace));
                 }

--- a/src/utils/split-text.js
+++ b/src/utils/split-text.js
@@ -49,8 +49,8 @@ export function splitText(el, key, splitOn, includePrevious, preserveWhitespace)
                 allElements.push(createText(' '));
             }
             // Concatenate the split text children back into the full array
-            const useSegmenter = splitOn === "" && typeof Intl.Segmenter === "function";
-            each(useSegmenter ? [...new Intl.Segmenter().segment(contents)].map((x) => x.segment) : contents.split(splitOn), function (splitText, i) {
+            var useSegmenter = splitOn === "" && typeof Intl.Segmenter === "function";
+            each(useSegmenter ? Array.from(new Intl.Segmenter().segment(contents)).map(function(x){return x.segment}) : contents.split(splitOn), function (splitText, i) {
                 if (i && preserveWhitespace) {
                     allElements.push(createElement(F, "whitespace", " ", preserveWhitespace));
                 }

--- a/tests/features/splitting.chars.js
+++ b/tests/features/splitting.chars.js
@@ -83,6 +83,17 @@ test('a nested empty element', function() {
   expect(results[0].words.length).toBe(0);
 });
 
+test('an element with emojis', function () {
+  var $el = document.createElement("div");
+  $el.innerHTML = "Hello 👨‍👩‍👧‍👦⭐️";
+
+  var results = Splitting({ target: $el, by: 'chars' });
+
+  expect(results.length).toBe(1);
+  expect(results[0].chars.length).toBe(7);
+  expect(results[0].words.length).toBe(2);
+});
+
 test('a multi-level nested empty element', function() {
   // todo
 });

--- a/tests/features/splitting.words.js
+++ b/tests/features/splitting.words.js
@@ -49,6 +49,22 @@ test("mixed content with spaces around words", () => {
   expect(actual).toBe(expected);
 });
 
+test("an element with a multiple words and emojis", () => {
+  var $el = document.createElement("div");
+  $el.innerHTML = "with multiple words and 🤔 🍌bananas! 👨‍👩‍👧‍👦";
+
+  var els = Splitting({ target: $el, by: "words" });
+  expect(els.length).toBe(1);
+  expect(els[0].words.length).toBe(7);
+  expect(els[0].words[0].textContent).toBe("with");
+  expect(els[0].words[1].textContent).toBe("multiple");
+  expect(els[0].words[2].textContent).toBe("words");
+  expect(els[0].words[3].textContent).toBe("and");
+  expect(els[0].words[4].textContent).toBe("🤔");
+  expect(els[0].words[5].textContent).toBe("🍌bananas!");
+  expect(els[0].words[6].textContent).toBe("👨‍👩‍👧‍👦");
+});
+
 test("a nested empty element", () => {
   // todo
 });


### PR DESCRIPTION
This fixes emojis for browsers that support the `Intl.Segmenter`. If it is not supported it falls back to the previous way of splitting the characters using the array split function. 